### PR TITLE
Fix depending on a Git version of the package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   parser: '@typescript-eslint/parser',  // Specifies the ESLint parser
+  plugins: [
+    "@typescript-eslint"
+  ],
   extends: [
     'plugin:@typescript-eslint/recommended',  // Uses the recommended rules from the @typescript-eslint/eslint-plugin
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,9 +463,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha1-mKmTUWyFnrDVxMjwmDF6nqaNua0=",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+      "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
       "dev": true
     },
     "@types/mocha": {
@@ -493,25 +493,65 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.22.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
-      "integrity": "sha1-PV8pu1nmGp26FRPUkbBZ5Tbhbbw=",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.5.tgz",
+      "integrity": "sha512-m31cPEnbuCqXtEZQJOXAHsHvtoDi9OVaeL5wZnO2KZTnkvELk+u6J6jHg+NzvWQxk+87Zjbc4lJS4NHmgImz6Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.22.0",
-        "@typescript-eslint/scope-manager": "4.22.0",
-        "debug": "^4.1.1",
+        "@typescript-eslint/experimental-utils": "4.28.5",
+        "@typescript-eslint/scope-manager": "4.28.5",
+        "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
-        "lodash": "^4.17.15",
-        "regexpp": "^3.0.0",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
+        "regexpp": "^3.1.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.5.tgz",
+          "integrity": "sha512-PHLq6n9nTMrLYcVcIZ7v0VY1X7dK309NM8ya9oL/yG8syFINIMHxyr2GzGoBYUdv3NUfCOqtuqps0ZmcgnZTfQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.28.5",
+            "@typescript-eslint/visitor-keys": "4.28.5"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.5.tgz",
+          "integrity": "sha512-MruOu4ZaDOLOhw4f/6iudyks/obuvvZUAHBDSW80Trnc5+ovmViLT2ZMDXhUV66ozcl6z0LJfKs1Usldgi/WCA==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.5.tgz",
+          "integrity": "sha512-dva/7Rr+EkxNWdJWau26xU/0slnFlkh88v3TsyTgRS/IIYFi5iIfpCFM4ikw0vQTFUR9FYSSyqgK4w64gsgxhg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.28.5",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -520,17 +560,93 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.22.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
-      "integrity": "sha1-aHZRZ8ylMReOe2UKU0VubgvvOx8=",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.5.tgz",
+      "integrity": "sha512-bGPLCOJAa+j49hsynTaAtQIWg6uZd8VLiPcyDe4QPULsvQwLHGLSGKKcBN8/lBxIX14F74UEMK2zNDI8r0okwA==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.22.0",
-        "@typescript-eslint/types": "4.22.0",
-        "@typescript-eslint/typescript-estree": "4.22.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^2.0.0"
+        "@types/json-schema": "^7.0.7",
+        "@typescript-eslint/scope-manager": "4.28.5",
+        "@typescript-eslint/types": "4.28.5",
+        "@typescript-eslint/typescript-estree": "4.28.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.5.tgz",
+          "integrity": "sha512-PHLq6n9nTMrLYcVcIZ7v0VY1X7dK309NM8ya9oL/yG8syFINIMHxyr2GzGoBYUdv3NUfCOqtuqps0ZmcgnZTfQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.28.5",
+            "@typescript-eslint/visitor-keys": "4.28.5"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.5.tgz",
+          "integrity": "sha512-MruOu4ZaDOLOhw4f/6iudyks/obuvvZUAHBDSW80Trnc5+ovmViLT2ZMDXhUV66ozcl6z0LJfKs1Usldgi/WCA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.5.tgz",
+          "integrity": "sha512-FzJUKsBX8poCCdve7iV7ShirP8V+ys2t1fvamVeD1rWpiAnIm550a+BX/fmTHrjEpQJ7ZAn+Z7ZZwJjytk9rZw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.28.5",
+            "@typescript-eslint/visitor-keys": "4.28.5",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.5.tgz",
+          "integrity": "sha512-dva/7Rr+EkxNWdJWau26xU/0slnFlkh88v3TsyTgRS/IIYFi5iIfpCFM4ikw0vQTFUR9FYSSyqgK4w64gsgxhg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.28.5",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
@@ -1396,8 +1512,8 @@
     },
     "eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -1463,8 +1579,8 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
@@ -1472,8 +1588,8 @@
       "dependencies": {
         "estraverse": {
           "version": "5.2.0",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "npx mocha -- out/test/*.js",
-    "pretest": "npx eslint ./src/*.ts && npm run compile",
+    "pretest": "npx eslint src --ext ts && npm run compile",
     "build": "npx tsc",
     "compile": "npx tsc && npm run copyToDist",
     "copyToDist": "npx copyfiles --error --verbose --flat ./out/src/*.* ./dist/",
-    "prepack": "npm run test && npm run copyToDist",
+    "prepack": "npm install-test && npm run copyToDist",
     "watch": "npx tsc -w"
   },
   "keywords": [
@@ -27,11 +27,11 @@
     "@types/node": "^13.13.51",
     "@types/tmp": "^0.2.0",
     "@types/vscode": "^1.55.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "^4.28.5",
+    "@typescript-eslint/parser": "^4.28.5",
     "chai": "^4.3.4",
     "copyfiles": "2.4.1",
-    "eslint": "^7.25.0",
+    "eslint": "^7.31.0",
     "mocha": "^7.2.0",
     "nyc": "^15.1.0",
     "typescript": "^3.9.9"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "mocha -- out/test/*.js",
-    "pretest": "eslint ./src/*.ts && npm run compile",
-    "build": "tsc",
-    "compile": "tsc && npm run copyToDist",
-    "copyToDist": "copyfiles --error --verbose --flat ./out/src/*.* ./dist/",
+    "test": "npx mocha -- out/test/*.js",
+    "pretest": "npx eslint ./src/*.ts && npm run compile",
+    "build": "npx tsc",
+    "compile": "npx tsc && npm run copyToDist",
+    "copyToDist": "npx copyfiles --error --verbose --flat ./out/src/*.* ./dist/",
     "prepack": "npm run test && npm run copyToDist",
-    "watch": "tsc -w"
+    "watch": "npx tsc -w"
   },
   "keywords": [
     "vscode",

--- a/src/ExtensionUpdater.ts
+++ b/src/ExtensionUpdater.ts
@@ -45,7 +45,7 @@ export abstract class ExtensionUpdater {
     /** Key for storing the last installed version in the `globalState` */
     private installedExtensionVersionKey: string;
 
-    
+
     /** Extension publisher + name. 
      * This is used as a key to store the last installed version 
      * as well as for the name of the temporary downloaded .vsix file. */
@@ -154,10 +154,10 @@ export abstract class ExtensionUpdater {
                         console.error(`statusCode: ${resp.statusCode}`);
                         reject(new Error(`Download failed with status code: ${resp.statusCode}`));
                     }
-                    
+
                     // direct the downloaded bytes to the file
                     resp.pipe(localFile);
-                    
+
                     // The whole response has been received. Print out the result.
                     resp.on('close', () => {
                         console.log(`Done downloading extension package to ${downloadedPath.path}`);


### PR DESCRIPTION
When I added a dependency on the version of `vscode-extension-updater` in my Git branch, it wouldn't install. Turns out that the deployment process is a bit different in that context (you can simulate some of the problems by invoking `npm --prefix C:\path\to\local\version pack` without having some of the dependencies installed globally).

There are two significant changes:
- Run most commands in `scripts` through `npx` so that they can use the locally installed module rather than a system wide one
- Change `prepack` to use `install-test` instead of `test`, so that it installs the dependencies first (otherwise the `pretest` script will fail because the typescript-eslint packages aren't installed yet).